### PR TITLE
feat: add transformation server rock 0.49.0

### DIFF
--- a/feast-transformation-server/rock-ci-metadata.yaml
+++ b/feast-transformation-server/rock-ci-metadata.yaml
@@ -1,0 +1,6 @@
+integrations:
+  - consumer-repository: https://github.com/canonical/feast-operators.git
+
+    replace-image:
+      - file: charms/feast-ui/metadata.yaml
+        path: resources.oci-image.upstream-source

--- a/feast-transformation-server/rockcraft.yaml
+++ b/feast-transformation-server/rockcraft.yaml
@@ -1,4 +1,4 @@
-# Source: https://github.com/feast-dev/feast/blob/v0.49.0/sdk/python/feast/infra/transformation_servers/Dockerfile
+# Based on https://github.com/feast-dev/feast/blob/v0.49.0/sdk/python/feast/infra/transformation_servers/Dockerfile
 name: feast-transformation-server
 base: ubuntu@24.04
 version: '0.49.0'

--- a/feast-transformation-server/rockcraft.yaml
+++ b/feast-transformation-server/rockcraft.yaml
@@ -1,0 +1,50 @@
+# Source: https://github.com/feast-dev/feast/blob/v0.49.0/sdk/python/feast/infra/transformation_servers/Dockerfile
+name: feast-transformation-server
+base: ubuntu@24.04
+version: '0.49.0'
+summary: Feast feature transformation server rock
+description: |
+    This rock is responsible for applying feature transformations for Feast at serving time.
+platforms:
+  amd64:
+environment: 
+  # set PYTHONPATH to include packages installed with pip
+  PYTHONPATH: "usr/local/lib/python3.12/site-packages"
+
+services:
+  feast-transformation-server:
+    override: replace
+    summary: "Feast transformation server service"
+    command: python app.py
+    startup: enabled
+
+parts:
+  feast-transformation:
+    plugin: nil
+    source: https://github.com/feast-dev/feast
+    source-type: git
+    source-tag: v0.49.0
+    stage-packages:
+      - python3
+      - python-is-python3
+    build-packages:
+      - python3-pip
+    override-build: |
+
+      # Copy app code
+      cp sdk/python/feast/infra/transformation_servers/app.py $CRAFT_PART_INSTALL/app.py
+
+      # Copy necessary parts of the Feast codebase
+      mkdir -p $CRAFT_PART_INSTALL/sdk
+      cp -r sdk/python $CRAFT_PART_INSTALL/sdk/python
+      cp -r protos $CRAFT_PART_INSTALL/protos
+      cp -r go $CRAFT_PART_INSTALL/go
+      cp setup.py $CRAFT_PART_INSTALL/setup.py
+      cp pyproject.toml $CRAFT_PART_INSTALL/pyproject.toml
+      cp README.md $CRAFT_PART_INSTALL/README.md
+
+      # Install dependencies with pip, including extras for GCP, AWS and grpcio dependencies
+      # Note that upstream is missing grpcio dependency group, this is a bug
+      # filed in https://github.com/feast-dev/feast/issues/5564
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/lib/python3.12/site-packages
+      pip install --target=$CRAFT_PART_INSTALL/usr/local/lib/python3.12/site-packages --no-cache-dir '.[gcp,aws,grpcio]'

--- a/feast-transformation-server/tests/test_rock.py
+++ b/feast-transformation-server/tests/test_rock.py
@@ -1,0 +1,21 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import pytest
+import subprocess
+
+from charmed_kubeflow_chisme.rock import CheckRock
+
+
+@pytest.mark.abort_on_fail
+def test_rock():
+    """Test rock."""
+    check_rock = CheckRock("rockcraft.yaml")
+    rock_image = check_rock.get_name()
+    rock_version = check_rock.get_version()
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
+
+    subprocess.run(
+        ["docker", "run", "--rm", LOCAL_ROCK_IMAGE, "exec", "ls", "-la", "/app.py"],
+        check=True,
+    )

--- a/feast-transformation-server/tests/test_rock.py
+++ b/feast-transformation-server/tests/test_rock.py
@@ -15,6 +15,26 @@ def test_rock():
     rock_version = check_rock.get_version()
     LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
 
+    # Check python executable points to python3
+    result = subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            LOCAL_ROCK_IMAGE,
+            "exec",
+            "ls",
+            "-l",
+            "/usr/bin/python",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    output = result.stdout.strip()
+    assert "python3" in output, "/usr/bin/python is NOT pointing to python3"
+
+    # Check app.py exists in root dir
     subprocess.run(
         ["docker", "run", "--rm", LOCAL_ROCK_IMAGE, "exec", "ls", "-la", "/app.py"],
         check=True,

--- a/feast-transformation-server/tox.ini
+++ b/feast-transformation-server/tox.ini
@@ -1,0 +1,50 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+envlist = pack, export-to-docker, sanity, integration, update-requirements
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+
+[testenv:pack]
+passenv = *
+allowlist_externals =
+    rockcraft
+commands =
+    rockcraft pack
+
+[testenv:export-to-docker]
+passenv = *
+allowlist_externals =
+    bash
+    rockcraft
+    yq
+commands =
+    # export rock to docker
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys | .[0]" rockcraft.yaml) && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
+             DOCKER_IMAGE=$NAME:$VERSION && \
+             echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
+             rockcraft.skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+
+[testenv:sanity]
+passenv = *
+deps =
+    pytest
+    charmed-kubeflow-chisme
+commands =
+    # run rock tests
+    pytest -s -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+
+[testenv:integration]
+passenv = *
+allowlist_externals =
+    echo
+commands =
+    # TODO: Implement integration tests here


### PR DESCRIPTION
Closes #10 

Note: The rock-metadata.yaml is made up and the opened PR should be closed (it will not pass with empty one) tracking it in #17, this rock will not be integrated in our charms and currently rock automation does allow for empty integrations (to be fixed in https://github.com/canonical/charmed-analytics-ci/issues/9)

## Testing
1. Pack the rock and import to microk8s registry:
```
git clone https://github.com/canonical/feast-rocks.git
cd feast-rocks/feast-transformation-server
tox -e pack
tox -e export-to-docker
docker save feast-transformation-server:0.49.0 -o transformation.tar
microk8s ctr image import - < transformation.tar
```
Note the imported image name from the microk8s command output

2. Follow https://github.com/canonical/feast-operators/issues/51#issuecomment-3173757098