### PR TITLE
feat: add rock-metadata file for feast-transformation-server

### DIFF
--- a/feast-transformation-server/rock-ci-metadata.yaml
+++ b/feast-transformation-server/rock-ci-metadata.yaml
@@ -1,6 +1,1 @@
-integrations:
-  - consumer-repository: https://github.com/canonical/feast-operators.git
-
-    replace-image:
-      - file: charms/feast-ui/metadata.yaml
-        path: resources.oci-image.upstream-source
+integrations: []


### PR DESCRIPTION
Part of: https://github.com/canonical/feast-rocks/issues/12

No integrations needed for `feast-transformation-server` replaced code was there just to pass ci.