### PR TITLE
fix: create config folders and `chown` them to `daemon` user for `feast-ui`

### DIFF
--- a/feast-ui/rockcraft.yaml
+++ b/feast-ui/rockcraft.yaml
@@ -63,6 +63,9 @@ parts:
       cp -fr /usr/local/lib/python3.12/dist-packages/* $CRAFT_PART_INSTALL/usr/local/lib/python3.12/dist-packages/
       cp -fr /usr/local/bin/* $CRAFT_PART_INSTALL/usr/local/bin/
 
+      # make config dir
+      mkdir -p /home/ubuntu
+
   non-root-user:
     plugin: nil
     after: [feast-ui]
@@ -74,3 +77,6 @@ parts:
       # Add corect permission to the _daemon_ user 
       # https://documentation.ubuntu.com/rockcraft/en/latest/reference/rockcraft.yaml/#run-user
       chown -R 584792:584792 $CRAFT_PRIME/usr/local/lib/python3.12/dist-packages/feast/ui/build
+
+      install -d -o 584792 -g 584792 -m 770 \
+        home/ubuntu


### PR DESCRIPTION
This PR modifies the `rockcraft.yaml` of rocks used by `volumes-web-app` charm requiring to write config files to the filesystem.
With this PR, configuration folders are already created and owned by user `_daemon_`, so that the unprivileged `pebble` service running in the charm can read/write there.